### PR TITLE
Filters restructuring

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ occurs.
 Filters are defined at the time an ``net.sf.expectit.Expect`` instance is being created and they can
 be disabled and re-enabled while working with the Expect instance.
 
-The library comes with the filters for removing ANSI escape terminal and non-printable characters.
+The library comes with the filters for non-printable characters, ANSI color sequences, or all VT100 control sequences.
 There are also more general ``replaceInString`` and ``replaceInBuffer`` filters used to modify the input buffer using
 regular expressions. Here is an example:
 
@@ -203,7 +203,7 @@ regular expressions. Here is an example:
             .build();
 
 ```
-Note that you may need to add static import of the filter factory methods in your code.
+Note that you may need to add static import of the `BuiltinFilter` factory methods in your code.
 
 ## More examples
 

--- a/expectit-ant/src/main/java/net/sf/expectit/ant/filter/FiltersElement.java
+++ b/expectit-ant/src/main/java/net/sf/expectit/ant/filter/FiltersElement.java
@@ -20,7 +20,7 @@ package net.sf.expectit.ant.filter;
  * #L%
  */
 
-import static net.sf.expectit.filter.Filters.chain;
+import static net.sf.expectit.filter.FilterChain.chain;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/expectit-ant/src/main/java/net/sf/expectit/ant/filter/RemoveColorsElement.java
+++ b/expectit-ant/src/main/java/net/sf/expectit/ant/filter/RemoveColorsElement.java
@@ -25,7 +25,7 @@ import static net.sf.expectit.filter.BuiltinFilters.removeColors;
 import net.sf.expectit.filter.Filter;
 
 /**
- * An element corresponding to the {@link net.sf.expectit.filter.Filters#removeColors()} filter.
+ * An element corresponding to the {@link net.sf.expectit.filter.BuiltinFilters#removeColors()} filter.
  */
 public class RemoveColorsElement extends AbstractFilterElement {
 

--- a/expectit-ant/src/main/java/net/sf/expectit/ant/filter/RemoveColorsElement.java
+++ b/expectit-ant/src/main/java/net/sf/expectit/ant/filter/RemoveColorsElement.java
@@ -20,7 +20,7 @@ package net.sf.expectit.ant.filter;
  * #L%
  */
 
-import static net.sf.expectit.filter.Filters.removeColors;
+import static net.sf.expectit.filter.BuiltinFilters.removeColors;
 
 import net.sf.expectit.filter.Filter;
 

--- a/expectit-ant/src/main/java/net/sf/expectit/ant/filter/RemoveNonPrintableElement.java
+++ b/expectit-ant/src/main/java/net/sf/expectit/ant/filter/RemoveNonPrintableElement.java
@@ -20,7 +20,7 @@ package net.sf.expectit.ant.filter;
  * #L%
  */
 
-import static net.sf.expectit.filter.Filters.removeNonPrintable;
+import static net.sf.expectit.filter.BuiltinFilters.removeNonPrintable;
 
 import net.sf.expectit.filter.Filter;
 

--- a/expectit-ant/src/main/java/net/sf/expectit/ant/filter/RemoveNonPrintableElement.java
+++ b/expectit-ant/src/main/java/net/sf/expectit/ant/filter/RemoveNonPrintableElement.java
@@ -25,7 +25,7 @@ import static net.sf.expectit.filter.BuiltinFilters.removeNonPrintable;
 import net.sf.expectit.filter.Filter;
 
 /**
- * An element corresponding to the {@link net.sf.expectit.filter.Filters#removeNonPrintable()}
+ * An element corresponding to the {@link net.sf.expectit.filter.BuiltinFilters#removeNonPrintable()}
  * filter.
  */
 public class RemoveNonPrintableElement extends AbstractFilterElement {

--- a/expectit-core/src/main/java/net/sf/expectit/ExpectBuilder.java
+++ b/expectit-core/src/main/java/net/sf/expectit/ExpectBuilder.java
@@ -29,6 +29,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import net.sf.expectit.echo.EchoOutput;
 import net.sf.expectit.filter.Filter;
+import net.sf.expectit.filter.FilterChain;
 import net.sf.expectit.filter.Filters;
 
 /**
@@ -214,7 +215,7 @@ public class ExpectBuilder {
             Filter[] filters = new Filter[moreFilters.length + 1];
             filters[0] = filter;
             System.arraycopy(moreFilters, 0, filters, 1, moreFilters.length);
-            this.filter = Filters.chain(filters);
+            this.filter = FilterChain.chain(filters);
         }
         return this;
     }

--- a/expectit-core/src/main/java/net/sf/expectit/ExpectBuilder.java
+++ b/expectit-core/src/main/java/net/sf/expectit/ExpectBuilder.java
@@ -205,7 +205,7 @@ public class ExpectBuilder {
      * @param filter      the filter
      * @param moreFilters more filter to apply. if specified then all the filters are combined
      *                    using the
-     *                    {@link Filters#chain(Filter...)} method.s
+     *                    {@link FilterChain#chain(Filter...)} method.s
      * @return this
      */
     public final ExpectBuilder withInputFilters(Filter filter, Filter... moreFilters) {

--- a/expectit-core/src/main/java/net/sf/expectit/filter/BuiltinFilters.java
+++ b/expectit-core/src/main/java/net/sf/expectit/filter/BuiltinFilters.java
@@ -1,0 +1,96 @@
+package net.sf.expectit.filter;
+
+/*
+ * #%L
+ * ExpectIt
+ * %%
+ * Copyright (C) 2014 Alexey Gavrilov and contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import java.util.regex.Pattern;
+
+/**
+ * The factory for built-in filters.
+ *
+ * @author Alexey Gavrilov
+ */
+public final class BuiltinFilters {
+
+    /**
+     * The regular expression and pattern which matches
+     * <a href="http://en.wikipedia.org/wiki/ANSI_escape_code#Colors">ANSI escape
+     * sequences for colors</a>.
+     */
+    private static final String COLORS_REGEXP_STRING = "\\e\\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]";
+    public static final Pattern COLORS_PATTERN = Pattern.compile(COLORS_REGEXP_STRING);
+
+    /**
+     * This regular expression and patter that match VT100 sequences.
+     * <p>
+     * This will also match ANSI colors.<br>
+     * See {@link BuiltinFilters#COLORS_PATTERN}
+     */
+    private static final String VT100_REGEXP_STRING = "" +
+            "\\e\\[(\\d+;)*(\\d+)?[ABCDHJKLMfmnr]|" +
+            "\\e\\[\\?\\d*[hlm]|" +
+            "\\e[78EDHM=]";
+    public static final Pattern VT100_PATTERN = Pattern.compile(VT100_REGEXP_STRING);
+
+    /**
+     * The regular expression which matches non printable characters: {@code
+     * [\x00\x08\x0B\x0C\x0E-\x1F]}.
+     */
+    public static final Pattern NON_PRINTABLE_PATTERN = Pattern.compile(
+            "[\\x00\\x08\\x0B\\x0C\\x0E-\\x1F]");
+
+    private BuiltinFilters() {
+    }
+
+    /**
+     * Creates a filter which removes
+     * <a href="http://en.wikipedia.org/wiki/ANSI_escape_code#Colors">ANSI
+     * escape sequences for colors</a> in the input.
+     *
+     * @return the filter
+     */
+    public static Filter removeColors() {
+        return Filters.replaceInBuffer(COLORS_PATTERN, "");
+    }
+
+    /**
+     * Creates a filter which removes all VT100 control sequences in the input.
+     * <p>
+     * This will also remove ANSI colors.<br>
+     * See {@link BuiltinFilters#removeColors()}
+     *
+     * @return the filter
+     */
+    public static Filter removeVt100Sequences() {
+        return Filters.replaceInBuffer(VT100_PATTERN, "");
+    }
+
+    /**
+     * Creates a filter which removes all the non-printable characters matching {@link
+     * #NON_PRINTABLE_PATTERN} in the
+     * input string.
+     *
+     * @return the filter
+     */
+    public static Filter removeNonPrintable() {
+        return Filters.replaceInString(NON_PRINTABLE_PATTERN, "");
+    }
+
+}

--- a/expectit-core/src/main/java/net/sf/expectit/filter/Filter.java
+++ b/expectit-core/src/main/java/net/sf/expectit/filter/Filter.java
@@ -37,7 +37,7 @@ public interface Filter {
      *
      * @param string a chunk of input data read from the input stream. Can not be {@code null}.
      *               If the filter
-     *               works in the {@link Filters#chain(Filter...)}, then the string is the result
+     *               works in the {@link FilterChain#chain(Filter...)}, then the string is the result
      *               of preceding filter
      * @param buffer the reference to the input buffer. Can be used to modify the entire buffer
      *               contents.

--- a/expectit-core/src/main/java/net/sf/expectit/filter/FilterChain.java
+++ b/expectit-core/src/main/java/net/sf/expectit/filter/FilterChain.java
@@ -1,0 +1,79 @@
+package net.sf.expectit.filter;
+
+/*
+ * #%L
+ * ExpectIt
+ * %%
+ * Copyright (C) 2014 Alexey Gavrilov and contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+/**
+ * The factory for filter chains.
+ *
+ * @author Alexey Gavrilov
+ */
+public final class FilterChain {
+
+    private FilterChain() {
+    }
+
+    /**
+     * Combines the filters in a filter chain.
+     * <p/>
+     * The given filters are applied one by one in the order that hey appear in the method
+     * argument list.
+     * <p/>
+     * The string returns by the
+     * {@link Filter#beforeAppend(String, StringBuilder)} method of one filter is passed a
+     * parameter to the next one if it is not {@code null}. If it is {@code null},
+     * then the {@code beforeAppend}
+     * won't be called any more and the latest non-null result is appended to the expect internal
+     * buffer.
+     * <p/>
+     * If the return value of the {@link Filter#afterAppend(StringBuilder)} method is true,
+     * then all the calls
+     * of this method on the consequent filters will be suppressed.
+     *
+     * @param filters the filters, not {@code null}
+     * @return the combined filter
+     */
+    public static Filter chain(final Filter... filters) {
+        return new FilterAdapter() {
+            @Override
+            protected String doBeforeAppend(String string, StringBuilder buffer) {
+                String previousResult = null;
+                for (Filter filter : filters) {
+                    string = filter.beforeAppend(string, buffer);
+                    if (string == null) {
+                        return previousResult;
+                    }
+                    previousResult = string;
+                }
+                return string;
+            }
+
+            @Override
+            protected boolean doAfterAppend(StringBuilder buffer) {
+                for (Filter filter : filters) {
+                    if (filter.afterAppend(buffer)) {
+                        return true;
+                    }
+                }
+                return false;
+            }
+        };
+    }
+}

--- a/expectit-core/src/main/java/net/sf/expectit/filter/Filters.java
+++ b/expectit-core/src/main/java/net/sf/expectit/filter/Filters.java
@@ -73,6 +73,8 @@ public final class Filters {
      * String)} but takes the regular expression
      * as string.
      *
+     * TODO: update after redesign
+     *
      * @param regexp      the regular expression
      * @param replacement the string to be substituted for each match
      * @return the filter
@@ -89,6 +91,8 @@ public final class Filters {
      * The method just calls {@link String#replaceAll(String, String)} for the entire buffer
      * contents every time new
      * data arrives,
+     *
+     * TODO: update after redesign
      *
      * @param regexp      the regular expression
      * @param replacement the string to be substituted for each match
@@ -132,6 +136,8 @@ public final class Filters {
      * The method just calls {@link String#replaceAll(String, String)} for the entire buffer
      * contents every time new
      * data arrives,
+     *
+     * TODO: update after redesign
      *
      * @param regexp      the regular expression
      * @param replacement the string to be substituted for each match

--- a/expectit-core/src/test/java/net/sf/expectit/KarafExample.java
+++ b/expectit-core/src/test/java/net/sf/expectit/KarafExample.java
@@ -20,9 +20,9 @@ package net.sf.expectit;
  * #L%
  */
 
-import static net.sf.expectit.filter.Filters.chain;
-import static net.sf.expectit.filter.Filters.removeColors;
-import static net.sf.expectit.filter.Filters.removeNonPrintable;
+import static net.sf.expectit.filter.FilterChain.chain;
+import static net.sf.expectit.filter.BuiltinFilters.removeColors;
+import static net.sf.expectit.filter.BuiltinFilters.removeNonPrintable;
 import static net.sf.expectit.matcher.Matchers.contains;
 import static net.sf.expectit.matcher.Matchers.eof;
 import static net.sf.expectit.matcher.Matchers.regexp;

--- a/expectit-core/src/test/java/net/sf/expectit/SshExample.java
+++ b/expectit-core/src/test/java/net/sf/expectit/SshExample.java
@@ -20,8 +20,8 @@ package net.sf.expectit;
  * #L%
  */
 
-import static net.sf.expectit.filter.Filters.removeColors;
-import static net.sf.expectit.filter.Filters.removeNonPrintable;
+import static net.sf.expectit.filter.BuiltinFilters.removeColors;
+import static net.sf.expectit.filter.BuiltinFilters.removeNonPrintable;
 import static net.sf.expectit.matcher.Matchers.contains;
 import static net.sf.expectit.matcher.Matchers.regexp;
 

--- a/expectit-core/src/test/java/net/sf/expectit/SshJExample.java
+++ b/expectit-core/src/test/java/net/sf/expectit/SshJExample.java
@@ -22,8 +22,8 @@ package net.sf.expectit;
 
 
 import static net.schmizz.sshj.connection.channel.direct.Session.Shell;
-import static net.sf.expectit.filter.Filters.removeColors;
-import static net.sf.expectit.filter.Filters.removeNonPrintable;
+import static net.sf.expectit.filter.BuiltinFilters.removeColors;
+import static net.sf.expectit.filter.BuiltinFilters.removeNonPrintable;
 import static net.sf.expectit.matcher.Matchers.contains;
 import static net.sf.expectit.matcher.Matchers.regexp;
 

--- a/expectit-core/src/test/java/net/sf/expectit/WinProcessTest.java
+++ b/expectit-core/src/test/java/net/sf/expectit/WinProcessTest.java
@@ -22,7 +22,7 @@ package net.sf.expectit;
 
 import static net.sf.expectit.TestUtils.LONG_TIMEOUT;
 import static net.sf.expectit.TestUtils.SMALL_TIMEOUT;
-import static net.sf.expectit.filter.Filters.removeNonPrintable;
+import static net.sf.expectit.filter.BuiltinFilters.removeNonPrintable;
 import static net.sf.expectit.matcher.Matchers.contains;
 import static net.sf.expectit.matcher.Matchers.eof;
 import static org.junit.Assert.assertFalse;

--- a/expectit-core/src/test/java/net/sf/expectit/filter/FilterTest.java
+++ b/expectit-core/src/test/java/net/sf/expectit/filter/FilterTest.java
@@ -21,7 +21,7 @@ package net.sf.expectit.filter;
  */
 
 import static net.sf.expectit.TestUtils.mockInputStream;
-import static net.sf.expectit.filter.Filters.chain;
+import static net.sf.expectit.filter.FilterChain.chain;
 import static net.sf.expectit.filter.Filters.replaceInBuffer;
 import static net.sf.expectit.filter.Filters.replaceInString;
 import static net.sf.expectit.matcher.Matchers.contains;
@@ -43,7 +43,7 @@ public class FilterTest {
     public void testNonPrintable() throws Exception {
         Expect expect = new ExpectBuilder()
                 .withInputs(mockInputStream("\u0000\u0008x").getStream())
-                .withInputFilters(Filters.removeNonPrintable())
+                .withInputFilters(BuiltinFilters.removeNonPrintable())
                 .build();
         assertEquals(expect.expect(contains("x")).getBefore(), "");
         expect.close();
@@ -54,7 +54,7 @@ public class FilterTest {
         String str = "abc\u001b[31m\u001B[7mdef\u001B[01;31m\u001B[KX\u001B[m\u001B[K";
         Expect expect = new ExpectBuilder()
                 .withInputs(mockInputStream(str + "x").getStream())
-                .withInputFilters(Filters.removeColors())
+                .withInputFilters(BuiltinFilters.removeColors())
                 .build();
         assertEquals(expect.expect(contains("x")).getBefore(), "abcdefX");
         expect.close();


### PR DESCRIPTION
This PR contains restructuring of the Filters class.

What was done:
- split built-in filters into a separate `BuiltinFilters` class
- added a VT100 sequence filter into the new `BuiltinFilters` class
- split `Filters#chain(...)` method into a separate `FilterChain` class

Why:
It makes it easier for new users to understand the purpose of each of the new classes.
`BuiltinFilters` class contains built-in filters that can be used out-of-the-box.
`Fitlers` class is now a class which can be used to build new custom filters.
`FilterChain` class is used for building filter-chains, nothing else.

By separating these 3 constructs into separate classes, new users will have an easier time picking up on how filtering works in ExpectIt.

Downside:
Doing this breaks compatibility with existing code that was importing `Filters` class to use the built-in filters. Users will have to change imports to the new `BuiltinFilters` class.
Same with the new `FilterChain` class.