### PR TITLE
Use LANG=C in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ not be performed concurrently.
 Here is an example of interacting with a spawn process:
 
 ```java
-        Process process = Runtime.getRuntime().exec("/bin/sh");
+        Process process = Runtime.getRuntime().exec("/bin/sh", new String[] {"LANG=C"});
 
         Expect expect = new ExpectBuilder()
                 .withInputs(process.getInputStream())


### PR DESCRIPTION
Incomplete fix: I don't know where to add the environment for the JSch example, and I haven't checked the code in the `examples/` directory.